### PR TITLE
Update interval_time_picker.dart

### DIFF
--- a/lib/interval_time_picker.dart
+++ b/lib/interval_time_picker.dart
@@ -1607,11 +1607,14 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
       minuteMarkerValues
           .add(TimeOfDay(hour: 0, minute: i * widget.visibleStep));
     }
+    final Color disabledColor = Theme.of(context).disabledColor;
 
     return <_TappableLabel>[
       for (final TimeOfDay timeOfDay in minuteMarkerValues)
         _buildTappableLabel(
-          textStyle: textStyle,
+          textStyle: (timeOfDay.minute % widget.interval == 0)
+              ? textStyle
+              : textStyle!.copyWith(color: disabledColor),
           selectedValue: selectedValue,
           inner: false,
           value: timeOfDay.minute,


### PR DESCRIPTION
Add: a disable color ,if  interval is added to make other minutes markers non-tappable.